### PR TITLE
fix hardcoded resource during uri construction

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -206,11 +206,11 @@ namespace sio
             ss<<"ws://";
 #endif
             if (m_sid.size()==0) {
-                ss<<uo.get_host()<<":"<<uo.get_port()<<"/socket.io/?EIO=4&transport=websocket&t="<<time(NULL)<<queryString;
+                ss<<uo.get_host()<<":"<<uo.get_port()<<uo.get_resource()<<"/?EIO=4&transport=websocket&t="<<time(NULL)<<queryString;
             }
             else
             {
-                ss<<uo.get_host()<<":"<<uo.get_port()<<"/socket.io/?EIO=4&transport=websocket&sid="<<m_sid<<"&t="<<time(NULL)<<queryString;
+                ss<<uo.get_host()<<":"<<uo.get_port()<<uo.get_resource()<<"/?EIO=4&transport=websocket&sid="<<m_sid<<"&t="<<time(NULL)<<queryString;
             }
             lib::error_code ec;
             client_type::connection_ptr con = m_client.get_connection(ss.str(), ec);


### PR DESCRIPTION
I corrected the resource that was hardcoded during the creation of the URI.

The connection should be : 
> sio::client h;
> h.connect("http://127.0.0.1:3000/socket.io");

Or maybe define the resource "/socket.io" by default if it is not specified during the connect call.

