### PR TITLE
Use boost::lexical_cast instead of std::stoi for Android compatibility.

### DIFF
--- a/src/internal/sio_packet.cpp
+++ b/src/internal/sio_packet.cpp
@@ -9,6 +9,7 @@
 #include <rapidjson/encodedstream.h>
 #include <rapidjson/writer.h>
 #include <cassert>
+#include <boost/lexical_cast.hpp>
 
 #define kBIN_PLACE_HOLDER "_placeholder"
 
@@ -259,7 +260,7 @@ namespace sio
             pos++;
             if (_type == type_binary_event || _type == type_binary_ack) {
                 size_t score_pos = payload_ptr.find('-');
-                _pending_buffers = stoi(payload_ptr.substr(pos,score_pos));
+                _pending_buffers = boost::lexical_cast<unsigned>(payload_ptr.substr(pos,score_pos));
                 pos = score_pos+1;
             }
         }
@@ -299,7 +300,7 @@ namespace sio
 
         if(pos<json_pos)//we've got pack id.
         {
-            _pack_id = stoi(payload_ptr.substr(pos,json_pos - pos));
+            _pack_id = boost::lexical_cast<int>(payload_ptr.substr(pos,json_pos - pos));
         }
         if (_frame == frame_message && (_type == type_binary_event || _type == type_binary_ack)) {
             //parse later when all buffers are arrived.


### PR DESCRIPTION
I've been trying to build the socket IO client using the Android NDK (10e). The NDK misses some std string functions and stoi is one of them. Boost's lexical_cast is functionally equivalent to stoi, so I replaced them. This allowed me to finish the android build.