### PR TITLE
Add options to choose between static and dynamic libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ PROJECT(sioclient)
 option(BUILD_SHARED_LIBS "Build the shared library" OFF)
 option(Boost_USE_STATIC_LIBS "Use Boost static version" ON)
 
+set(MAJOR 1)
+set(MINOR 6)
+set(PATCH 0)
+
 if(NOT CMAKE_BUILD_TYPE )
 MESSAGE(STATUS "not define build type, set to release" )
 set(CMAKE_BUILD_TYPE Release )
@@ -33,6 +37,13 @@ target_include_directories(sioclient PRIVATE ${Boost_INCLUDE_DIRS}
 set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
 set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
 target_link_libraries(sioclient PRIVATE ${Boost_LIBRARIES})
+if(BUILD_SHARED_LIBS)
+set_target_properties(sioclient
+	PROPERTIES
+		SOVERSION ${MAJOR}
+		VERSION ${MAJOR}.${MINOR}.${PATCH}
+	)
+endif()
 list(APPEND TARGET_LIBRARIES sioclient)
 
 find_package(OpenSSL)
@@ -49,6 +60,13 @@ set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
 set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
 target_link_libraries(sioclient_tls PRIVATE ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} )
 target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)
+if(BUILD_SHARED_LIBS)
+set_target_properties(sioclient_tls
+	PROPERTIES
+		SOVERSION ${MAJOR}
+		VERSION ${MAJOR}.${MINOR}.${PATCH}
+	)
+endif()
 list(APPEND TARGET_LIBRARIES sioclient_tls)
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 PROJECT(sioclient)
 
+option(BUILD_SHARED_LIBS "Build the shared library" OFF)
+option(Boost_USE_STATIC_LIBS "Use Boost static version" ON)
+
 if(NOT CMAKE_BUILD_TYPE )
 MESSAGE(STATUS "not define build type, set to release" )
 set(CMAKE_BUILD_TYPE Release )
@@ -11,7 +14,6 @@ endif()
 
 set(BOOST_VER "1.55.0" CACHE STRING "boost version" )
 
-set(Boost_USE_STATIC_LIBS ON) 
 set(Boost_USE_MULTITHREADED ON) 
 set(Boost_USE_STATIC_RUNTIME OFF) 
 find_package(Boost ${BOOST_VER} REQUIRED COMPONENTS system date_time random) 
@@ -21,7 +23,7 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR}/src/internal ALL_SRC)
 file(GLOB ALL_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/*.h )
 set(SIO_INCLUDEDIR ${CMAKE_CURRENT_LIST_DIR})
 
-add_library(sioclient STATIC ${ALL_SRC}) 
+add_library(sioclient ${ALL_SRC})
 target_include_directories(sioclient PRIVATE ${Boost_INCLUDE_DIRS} 
     ${CMAKE_CURRENT_LIST_DIR}/src 
     ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp 
@@ -35,7 +37,7 @@ list(APPEND TARGET_LIBRARIES sioclient)
 
 find_package(OpenSSL)
 if(OPENSSL_FOUND)
-add_library(sioclient_tls STATIC ${ALL_SRC})
+add_library(sioclient_tls ${ALL_SRC})
 target_include_directories(sioclient_tls PRIVATE ${Boost_INCLUDE_DIRS} 
     ${CMAKE_CURRENT_LIST_DIR}/src 
     ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp 


### PR DESCRIPTION
For now, socket.io-client-cpp is all static but we could want to choose between static and dynamic.
Furthermore, in some distribution, boost comes only in dynamic.

I propose then to make an option of Boost_USE_STATIC_LIBS (ON by default) and of BUILD_SHARED_LIBS (OFF by default)

By default the behavior will stay the same but we can change with
cmake ../ -DBoost_USE_STATIC_LIBS=OFF -DBUILD_SHARED_LIBS=ON