### PR TITLE
Standard install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,13 +52,9 @@ list(APPEND TARGET_LIBRARIES sioclient_tls)
 endif()
 
 install(FILES ${ALL_HEADERS} 
-    DESTINATION "${CMAKE_CURRENT_LIST_DIR}/build/include"
+    DESTINATION "include"
 )
 
 install(TARGETS ${TARGET_LIBRARIES}
-    DESTINATION "${CMAKE_CURRENT_LIST_DIR}/build/lib/${CMAKE_BUILD_TYPE}"
-)
-
-install(FILES ${Boost_LIBRARIES} 
-    DESTINATION "${CMAKE_CURRENT_LIST_DIR}/build/lib/${CMAKE_BUILD_TYPE}"
+    DESTINATION "lib"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,12 @@ list(APPEND TARGET_LIBRARIES sioclient_tls)
 
 endif()
 
+include(GNUInstallDirs)
+
 install(FILES ${ALL_HEADERS} 
-    DESTINATION "include"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(TARGETS ${TARGET_LIBRARIES}
-    DESTINATION "lib"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )


### PR DESCRIPTION
For now, the install path is hardcoded inside the project folder. I don't know why exactly but it is not really useful for deployment.

I propose to use the standard way to do, allowing us also to use CMAKE_INSTALL_PREFIX to deploy properly the library and its headers.
