### PR TITLE
Remove Cocoapods from iOS installation guide.

### DIFF
--- a/INSTALL_IOS.md
+++ b/INSTALL_IOS.md
@@ -1,12 +1,6 @@
 ## iOS
 
-### Option 1: Cocoapods
-
-```
-pod 'SocketIO-Client-CPP'
-```
-
-### Option 2: Create a static library
+### Option 1: Create a static library
 
 1. Create a static library
 1. Copy the header files into xcode
@@ -26,7 +20,7 @@ libtool -static -o libUniversalDebug.a Debug-iphoneos/libsioclient.a Debug-iphon
 ```
 
 
-### Option 3: Manual integration
+### Option 2: Manual integration
 
 Use this [shell](https://gist.github.com/melode11/a90114a2abf009ca22ea) to download and build boost completely automattically. It installs boost to `<shell folder>/prefix`.
 


### PR DESCRIPTION
As mentioned in #67, Cocoapods is not supported at this time.