### PR TITLE
client: support custom HTTP headers

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -63,7 +63,7 @@ namespace sio
         sync_close();
     }
     
-    void client_impl::connect(const string& uri, const map<string,string>& query)
+    void client_impl::connect(const string& uri, const map<string,string>& query, const map<string, string>& headers)
     {
         if(m_reconn_timer)
         {
@@ -98,6 +98,8 @@ namespace sio
             query_str.append(it->second);
         }
         m_query_string=move(query_str);
+
+        m_http_headers = headers;
 
         this->reset_states();
         m_client.get_io_service().dispatch(lib::bind(&client_impl::connect_impl,this,uri,m_query_string));
@@ -218,6 +220,10 @@ namespace sio
                 m_client.get_alog().write(websocketpp::log::alevel::app,
                                           "Get Connection Error: "+ec.message());
                 break;
+            }
+
+            for( auto&& header: m_http_headers ) {
+                con->replace_header(header.first, header.second);
             }
 
             m_client.connect(con);

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -97,7 +97,8 @@ namespace sio
         }
         
         // Client Functions - such as send, etc.
-        void connect(const std::string& uri, const std::map<std::string, std::string>& queryString);
+        void connect(const std::string& uri, const std::map<std::string, std::string>& queryString,
+                     const std::map<std::string, std::string>& httpExtraHeaders);
         
         sio::socket::ptr const& socket(const std::string& nsp);
         
@@ -182,6 +183,7 @@ namespace sio
         std::string m_sid;
         std::string m_base_url;
         std::string m_query_string;
+        std::map<std::string, std::string> m_http_headers;
 
         unsigned int m_ping_interval;
         unsigned int m_ping_timeout;

--- a/src/sio_client.cpp
+++ b/src/sio_client.cpp
@@ -70,13 +70,18 @@ namespace sio
 
     void client::connect(const std::string& uri)
     {
-        const std::map<string,string> query;
-        m_impl->connect(uri, query);
+        m_impl->connect(uri, {}, {});
     }
 
     void client::connect(const std::string& uri, const std::map<string,string>& query)
     {
-        m_impl->connect(uri, query);
+        m_impl->connect(uri, query, {});
+    }
+
+    void client::connect(const std::string& uri, const std::map<std::string,std::string>& query,
+                         const std::map<std::string,std::string>& http_extra_headers)
+    {
+        m_impl->connect(uri, query, http_extra_headers);
     }
     
     socket::ptr const& client::socket(const std::string& nsp)

--- a/src/sio_client.h
+++ b/src/sio_client.h
@@ -58,6 +58,9 @@ namespace sio
 
         void connect(const std::string& uri, const std::map<std::string,std::string>& query);
 
+        void connect(const std::string& uri, const std::map<std::string,std::string>& query,
+                     const std::map<std::string,std::string>& http_extra_headers);
+
         void set_reconnect_attempts(int attempts);
 
         void set_reconnect_delay(unsigned millis);


### PR DESCRIPTION
Added another overload of client::connect that takes an std::map
of additional HTTP headers to be passed on to the server when connecting.
