### PR TITLE
Missing brackets in Readme File?

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ h.connect("http://127.0.0.1:3000");
 
 ```C++
 // emit event name only:
-h.socket->emit("login");
+h.socket()->emit("login");
 
 // emit text
 h.socket()->emit("add user", username);


### PR DESCRIPTION
Hi!
While looking into repo, I think I found something strange...like:
Missing brackets in Readme.MD
It looks like a typo. According to source code - https://github.com/socketio/socket.io-client-cpp/blob/f0ed359e0874d1227f17dc6e59bc5f091633764b/src/sio_client.cpp#L82