### PR TITLE
Change client_impl::send_impl() not to delay ping

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -264,13 +264,6 @@ namespace sio
     {
         if(m_con_state == con_opened)
         {
-            //delay the ping, since we already have message to send.
-            boost::system::error_code timeout_ec;
-            if(m_ping_timer)
-            {
-                m_ping_timer->expires_from_now(milliseconds(m_ping_interval),timeout_ec);
-                m_ping_timer->async_wait(lib::bind(&client_impl::ping,this,lib::placeholders::_1));
-            }
             lib::error_code ec;
             m_client.send(m_con,*payload_ptr,opcode,ec);
             if(ec)


### PR DESCRIPTION
This fixes an issue where a disconnect can go undetected.

In the case where `client_impl::send_impl()` continuously gets called with an interval less than `client_impl::m_ping_interval`, a disconnect due to network connectivity problems is never detected because the ping keeps getting delayed by `send_impl()`, thus not allowing a pong timeout to happen, which results in `client_impl::close_impl()` never being called.