### PR TITLE
add support for mingw-std-threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ target_include_directories(sioclient PRIVATE ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
 )
 
+if(MINGW_STD_THREADS)
+  target_include_directories(sioclient PRIVATE ${MINGW_STD_THREADS})
+  target_compile_definitions(sioclient PRIVATE -D_USE_MINGW_STD_THREADS -D_WEBSOCKETPP_NO_CPP11_THREAD_)
+endif()
+
 set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
 set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
 target_link_libraries(sioclient PRIVATE ${Boost_LIBRARIES})
@@ -55,6 +60,11 @@ target_include_directories(sioclient_tls PRIVATE ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
     ${OPENSSL_INCLUDE_DIR}
 )
+
+if(MINGW_STD_THREADS)
+  target_include_directories(sioclient_tls PRIVATE ${MINGW_STD_THREADS})
+  target_compile_definitions(sioclient_tls PRIVATE -D_USE_MINGW_STD_THREADS -D_WEBSOCKETPP_NO_CPP11_THREAD_)
+endif()
 
 set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
 set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,7 @@ cmake
 ./
 ```
 * CMake didn't allow merging static libraries,but they're all copied to `./build/lib`, you can DIY if you like.
+* If you are compiling with MinGW, you might need to use [mingw-std-threads](https://github.com/meganz/mingw-std-threads). Use `-DMINGW_STD_THREADS=<path to mingw-std-threads>` to enable.
 
 ### Without CMake
 1. Install boost, see [Boost setup](#boost_setup) section.

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -3,7 +3,9 @@
 
 #include <cstdint>
 #ifdef _WIN32
+#ifndef _USE_MINGW_STD_THREADS
 #define _WEBSOCKETPP_CPP11_THREAD_
+#endif
 #define BOOST_ALL_NO_LIB
 //#define _WEBSOCKETPP_CPP11_RANDOM_DEVICE_
 #define _WEBSOCKETPP_NO_CPP11_FUNCTIONAL_
@@ -35,6 +37,11 @@ typedef websocketpp::config::asio_client client_config;
 #include <memory>
 #include <map>
 #include <thread>
+#include <mutex>
+#ifdef _USE_MINGW_STD_THREADS
+#include "mingw.thread.h"
+#include "mingw.mutex.h"
+#endif
 #include "../sio_client.h"
 #include "sio_packet.h"
 


### PR DESCRIPTION
This allows socket.io-client-cpp to build successfully for me using the MinGW cross-compiler from [mxe.cc](http://mxe.cc/):

```
i686-w64-mingw32.static-cmake \
  -DBOOST_INCLUDEDIR:STRING=/opt/mxe/usr/i686-w64-mingw32.static/include/boost \
  -DBOOST_LIBRARYDIR=/opt/mxe/usr/i686-w64-mingw32.static/lib \
  -DBOOST_VER:STRING=1.60.0 \
  -DMINGW_STD_THREADS=$(pwd)/../mingw-std-threads
```
