### PR TITLE
allow resource path to be set in connection URI

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -214,7 +214,12 @@ namespace sio
             } else {
                 ss<<uo.get_host();
             }
-            ss<<":"<<uo.get_port()<<"/socket.io/?EIO=4&transport=websocket";
+
+            // If a resource path was included in the URI, use that, otherwise
+            // use the default /socket.io/.
+            const std::string path(uo.get_resource() == "/" ? "/socket.io/" : uo.get_resource());
+
+            ss<<":"<<uo.get_port()<<path<<"?EIO=4&transport=websocket";
             if(m_sid.size()>0){
                 ss<<"&sid="<<m_sid;
             }


### PR DESCRIPTION
This allows connection to a socket.io server that is using a path other than `/socket.io/`.