### PR TITLE
make all logging optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ target_include_directories(sioclient PRIVATE ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
 )
 
+if(SIO_CLIENT_DEBUG)
+  target_compile_definitions(sioclient PRIVATE -DSIO_CLIENT_DEBUG)
+endif()
+
 set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
 set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
 target_link_libraries(sioclient PRIVATE ${Boost_LIBRARIES})
@@ -55,6 +59,10 @@ target_include_directories(sioclient_tls PRIVATE ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
     ${OPENSSL_INCLUDE_DIR}
 )
+
+if(SIO_CLIENT_DEBUG)
+  target_compile_definitions(sioclient_tls PRIVATE -DSIO_CLIENT_DEBUG)
+endif()
 
 set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
 set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -12,10 +12,10 @@
 #include <mutex>
 #include <cmath>
 // Comment this out to disable handshake logging to stdout
-#if DEBUG || _DEBUG
-#define LOG(x) std::cout << x
+#if SIO_CLIENT_DEBUG
+#	define LOG(x) std::cout << x
 #else
-#define LOG(x)
+#	define LOG(x)
 #endif
 
 using boost::posix_time::milliseconds;
@@ -35,8 +35,8 @@ namespace sio
         m_reconn_delay_max(25000)
     {
         using websocketpp::log::alevel;
-#ifndef DEBUG
         m_client.clear_access_channels(alevel::all);
+#ifdef SIO_CLIENT_DEBUG
         m_client.set_access_channels(alevel::connect|alevel::disconnect|alevel::app);
 #endif
         // Initialize the Asio transport policy
@@ -251,7 +251,7 @@ namespace sio
         }
         if (m_con.expired())
         {
-            cerr << "Error: No active session" << endl;
+            LOG("Error: No active session" << endl);
         }
         else
         {
@@ -275,7 +275,7 @@ namespace sio
             m_client.send(m_con,*payload_ptr,opcode,ec);
             if(ec)
             {
-                cerr<<"Send failed,reason:"<< ec.message()<<endl;
+                LOG("Send failed,reason:"<< ec.message()<<endl);
             }
         }
     }
@@ -579,7 +579,7 @@ failed:
                              boost::asio::ssl::context::single_dh_use,ec);
         if(ec)
         {
-            cerr<<"Init tls failed,reason:"<< ec.message()<<endl;
+            LOG("Init tls failed,reason:"<< ec.message()<<endl);
         }
         
         return ctx;

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -13,23 +13,29 @@
 #define INTIALIZER(__TYPE__) (__TYPE__)
 #endif
 #include <websocketpp/client.hpp>
-#if _DEBUG || DEBUG
-#if SIO_TLS
-#include <websocketpp/config/debug_asio.hpp>
-typedef websocketpp::config::debug_asio_tls client_config;
+#ifdef SIO_CLIENT_DEBUG
+#	if SIO_TLS
+#		include <websocketpp/config/debug_asio.hpp>
+		typedef websocketpp::config::debug_asio_tls client_config;
+#	else
+#		include <websocketpp/config/debug_asio_no_tls.hpp>
+		typedef websocketpp::config::debug_asio client_config;
+#	endif //SIO_TLS
 #else
-#include <websocketpp/config/debug_asio_no_tls.hpp>
-typedef websocketpp::config::debug_asio client_config;
-#endif //SIO_TLS
-#else
-#if SIO_TLS
-#include <websocketpp/config/asio_client.hpp>
-typedef websocketpp::config::asio_tls_client client_config;
-#else
-#include <websocketpp/config/asio_no_tls_client.hpp>
-typedef websocketpp::config::asio_client client_config;
-#endif //SIO_TLS
-#endif //DEBUG
+#	if SIO_TLS
+#		include <websocketpp/config/asio_client.hpp>
+		typedef websocketpp::config::asio_tls_client client_config_base;
+#	else
+#		include <websocketpp/config/asio_no_tls_client.hpp>
+		typedef websocketpp::config::asio_client client_config_base;
+#	endif //SIO_TLS
+	struct client_config : public client_config_base {
+		static const websocketpp::log::level elog_level
+			= websocketpp::log::elevel::none;
+		static const websocketpp::log::level alog_level
+			= websocketpp::log::alevel::none;
+	};
+#endif //SIO_CLIENT_DEBUG
 #include <boost/asio/deadline_timer.hpp>
 
 #include <memory>

--- a/src/sio_socket.cpp
+++ b/src/sio_socket.cpp
@@ -6,10 +6,10 @@
 #include <queue>
 #include <cstdarg>
 
-#if DEBUG || _DEBUG
-#define LOG(x) std::cout << x
+#if SIO_CLIENT_DEBUG
+#	define LOG(x) std::cout << x
 #else
-#define LOG(x)
+#	define LOG(x)
 #endif
 
 #define NULL_GUARD(_x_)  \


### PR DESCRIPTION
This cherrypicks a commit from @palchukovsky, and adds one of my own to expose the #define option through cmake.