### PR TITLE
Remove unused parameters and reorder constructors to get rid of warnings

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -25,14 +25,14 @@ namespace sio
 {
     /*************************public:*************************/
     client_impl::client_impl() :
-        m_con_state(con_closed),
         m_ping_interval(0),
         m_ping_timeout(0),
         m_network_thread(),
-        m_reconn_attempts(0xFFFFFFFF),
-        m_reconn_made(0),
+        m_con_state(con_closed),
         m_reconn_delay(5000),
-        m_reconn_delay_max(25000)
+        m_reconn_delay_max(25000),
+        m_reconn_attempts(0xFFFFFFFF),
+        m_reconn_made(0)
     {
         using websocketpp::log::alevel;
 #ifndef DEBUG
@@ -285,12 +285,11 @@ namespace sio
         if(ec || m_con.expired())
         {
             if (ec != boost::asio::error::operation_aborted)
-                LOG("ping exit,con is expired?"<<m_con.expired()<<",ec:"<<ec.message()<<endl);
+                LOG("ping exit,con is expired?"<<m_con.expired()<<",ec:"<<ec.message()<<endl){};
             return;
         }
         packet p(packet::frame_ping);
-        m_packet_mgr.encode(p,
-                            [&](bool isBin,shared_ptr<const string> payload)
+        m_packet_mgr.encode(p, [&](bool /*isBin*/,shared_ptr<const string> payload)
         {
             lib::error_code ec;
             this->m_client.send(this->m_con, *payload, frame::opcode::text, ec);
@@ -370,7 +369,7 @@ namespace sio
         }
     }
 
-    void client_impl::on_fail(connection_hdl con)
+    void client_impl::on_fail(connection_hdl)
     {
         m_con.reset();
         m_con_state = con_closed;
@@ -449,7 +448,7 @@ namespace sio
         }
     }
     
-    void client_impl::on_message(connection_hdl con, client_type::message_ptr msg)
+    void client_impl::on_message(connection_hdl, client_type::message_ptr msg)
     {
         if (m_ping_timeout_timer) {
             boost::system::error_code ec;
@@ -495,7 +494,7 @@ namespace sio
             m_ping_timer.reset(new boost::asio::deadline_timer(m_client.get_io_service()));
             boost::system::error_code ec;
             m_ping_timer->expires_from_now(milliseconds(m_ping_interval), ec);
-            if(ec)LOG("ec:"<<ec.message()<<endl);
+            if(ec)LOG("ec:"<<ec.message()<<endl){};
             m_ping_timer->async_wait(lib::bind(&client_impl::ping,this,lib::placeholders::_1));
             LOG("On handshake,sid:"<<m_sid<<",ping interval:"<<m_ping_interval<<",ping timeout"<<m_ping_timeout<<endl);
             return;

--- a/src/internal/sio_packet.cpp
+++ b/src/internal/sio_packet.cpp
@@ -198,8 +198,8 @@ namespace sio
         _frame(frame_message),
         _type((isAck?type_ack : type_event) | type_undetermined),
         _nsp(nsp),
-        _message(msg),
         _pack_id(pack_id),
+        _message(msg),
         _pending_buffers(0)
     {
         assert((!isAck
@@ -210,8 +210,8 @@ namespace sio
         _frame(frame_message),
         _type(type),
         _nsp(nsp),
-        _message(msg),
         _pack_id(-1),
+        _message(msg),
         _pending_buffers(0)
     {
 

--- a/src/sio_client.h
+++ b/src/sio_client.h
@@ -80,8 +80,8 @@ namespace sio
         
     private:
         //disable copy constructor and assign operator.
-        client(client const& cl){}
-        void operator=(client const& cl){}
+        client(client const&){}
+        void operator=(client const&){}
         
         client_impl* m_impl;
     };

--- a/src/sio_socket.cpp
+++ b/src/sio_socket.cpp
@@ -228,8 +228,8 @@ namespace sio
     
     socket::impl::impl(client_impl *client,std::string const& nsp):
         m_client(client),
-        m_nsp(nsp),
-        m_connected(false)
+        m_connected(false),
+        m_nsp(nsp)
     {
         NULL_GUARD(client);
         if(m_client->opened())
@@ -449,7 +449,7 @@ namespace sio
         }
     }
     
-    void socket::impl::ack(int msgId, const string &name, const message::list &ack_message)
+    void socket::impl::ack(int msgId, const string &, const message::list &ack_message)
     {
         packet p(m_nsp, ack_message.to_array_message(),msgId,true);
         send_packet(p);

--- a/src/sio_socket.h
+++ b/src/sio_socket.h
@@ -91,8 +91,8 @@ namespace sio
         
     private:
         //disable copy constructor and assign operator.
-        socket(socket const& sock){}
-        void operator=(socket const& sock){}
+        socket(socket const&){}
+        void operator=(socket const&){}
 
         class impl;
         impl *m_impl;


### PR DESCRIPTION
Compiling this muddies up my output with warnings. I'm using gcc 6.3.1 with `-Wall -Wextra -pedantic -std=c++17 -O0 -g`