### PR TITLE
Support UInt64 values in string payloads

### DIFF
--- a/src/internal/sio_packet.cpp
+++ b/src/internal/sio_packet.cpp
@@ -141,6 +141,18 @@ namespace sio
         {
             return int_message::create(value.GetInt64());
         }
+        // TODO: decide between returning int64 and double
+#if 1
+        else if (value.IsUint64())
+        {
+          return int_message::create(value.GetInt64());
+        }
+#else
+        else if (value.IsUint64())
+        {
+          return double_message::create(value.GetDouble());
+        }
+#endif
         else if(value.IsDouble())
         {
             return double_message::create(value.GetDouble());

--- a/src/internal/sio_packet.cpp
+++ b/src/internal/sio_packet.cpp
@@ -141,18 +141,10 @@ namespace sio
         {
             return int_message::create(value.GetInt64());
         }
-        // TODO: decide between returning int64 and double
-#if 1
         else if (value.IsUint64())
         {
           return int_message::create(value.GetInt64());
         }
-#else
-        else if (value.IsUint64())
-        {
-          return double_message::create(value.GetDouble());
-        }
-#endif
         else if(value.IsDouble())
         {
             return double_message::create(value.GetDouble());

--- a/test/sio_test.cpp
+++ b/test/sio_test.cpp
@@ -225,5 +225,25 @@ BOOST_AUTO_TEST_CASE( test_packet_parse_4 )
 
 }
 
+BOOST_AUTO_TEST_CASE( test_packet_parse_5 )
+{
+    packet p;
+    bool hasbin = p.parse("42/nsp,1001[\"event\",17657333360744292000]");
+    BOOST_CHECK(!hasbin);
+    BOOST_CHECK(p.get_frame() == packet::frame_message);
+    BOOST_CHECK(p.get_type() == packet::type_event);
+    BOOST_CHECK(p.get_nsp() == "/nsp");
+    BOOST_CHECK(p.get_pack_id() == 1001);
+    BOOST_CHECK(p.get_message()->get_flag() == message::flag_array);
+    BOOST_REQUIRE(p.get_message()->get_vector().size() == 2);
+    BOOST_REQUIRE(p.get_message()->get_vector()[0]->get_flag() == message::flag_string);
+    BOOST_CHECK(p.get_message()->get_vector()[0]->get_string() == "event");
+    // TODO: decide between returning int64 and double
+    //BOOST_REQUIRE(p.get_message()->get_vector()[1]->get_flag() == message::flag_double);
+    //BOOST_CHECK(p.get_message()->get_vector()[1]->get_double() == 17657333360744292000U);
+    BOOST_REQUIRE(p.get_message()->get_vector()[1]->get_flag() == message::flag_integer);
+    BOOST_CHECK(p.get_message()->get_vector()[1]->get_int() == 17657333360744292000U);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/sio_test.cpp
+++ b/test/sio_test.cpp
@@ -225,6 +225,9 @@ BOOST_AUTO_TEST_CASE( test_packet_parse_4 )
 
 }
 
+/*
+ * Test parsing of UInt64 values. See #174.
+ */
 BOOST_AUTO_TEST_CASE( test_packet_parse_5 )
 {
     packet p;
@@ -238,9 +241,6 @@ BOOST_AUTO_TEST_CASE( test_packet_parse_5 )
     BOOST_REQUIRE(p.get_message()->get_vector().size() == 2);
     BOOST_REQUIRE(p.get_message()->get_vector()[0]->get_flag() == message::flag_string);
     BOOST_CHECK(p.get_message()->get_vector()[0]->get_string() == "event");
-    // TODO: decide between returning int64 and double
-    //BOOST_REQUIRE(p.get_message()->get_vector()[1]->get_flag() == message::flag_double);
-    //BOOST_CHECK(p.get_message()->get_vector()[1]->get_double() == 17657333360744292000U);
     BOOST_REQUIRE(p.get_message()->get_vector()[1]->get_flag() == message::flag_integer);
     BOOST_CHECK(p.get_message()->get_vector()[1]->get_int() == 17657333360744292000U);
 }


### PR DESCRIPTION
This is an attempt to address #174 by returning int_message (rather than null) when parsing a UInt64 value from a string payload. I've added a quick unit test to demonstrate the change.

So far in my personal testing this seems to work fine, but I'm not sure if there might be a better solution.