### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,6 +25,18 @@ cmake
 5. Add `<your boost install folder>/lib` to library search path, add `boost.lib`(Win32) or `-lboost`(Other) link option.
 6. Include `sio_client.h` in your client code where you want to use it.
 
+### With vcpkg
+
+You can download and install socket-io-client using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+    ```bash
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install socket-io-client
+    ```
+The socket-io-client port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Boost setup
 
 1. Download boost from [boost.org](http://www.boost.org/).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,14 +28,16 @@ cmake
 ### With vcpkg
 
 You can download and install socket-io-client using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-    ```bash
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    vcpkg install socket-io-client
-    ```
-The socket-io-client port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+vcpkg install socket-io-client
+```
+
+The Socket.IO client port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Boost setup
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ By virtue of being written in C++, this client works in several different platfo
 
 * [With CMAKE](./INSTALL.md#with-cmake)
 * [Without CMAKE](./INSTALL.md#without-cmake)
+* [With VCPKG](./INSTALL.md#with-vcpkg)
 * [iOS and OS X](./INSTALL_IOS.md)
  * Option 1: Cocoapods
  * Option 2: Create a static library


### PR DESCRIPTION
`socket-io-client` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `socket-io-client` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `socket-io-client`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, arm, uwp) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/socket-io-client/portfile.cmake). We try to keep the library maintained as close as possible to the original library.