### PR TITLE
Undefine emit macro for Qt compatibility

### DIFF
--- a/src/sio_client.h
+++ b/src/sio_client.h
@@ -6,6 +6,11 @@
 
 #ifndef SIO_CLIENT_H
 #define SIO_CLIENT_H
+
+#ifdef emit
+#undef emit
+#endif
+
 #include <string>
 #include <functional>
 #include "sio_message.h"


### PR DESCRIPTION
This library overlaps with Qt framework due to the usage of "emit". I managed to find a simple workaround for this issue, i undefined the emit macro. This way we no longer need `CONFIG+=no_keywords` in .pro file. I decided to take this approach because other Qt libraries extensively make use of **emit** and **no_keywords** causes emit to be undefined project-wide, thus making the whole project unable to compile.

I am not a Qt expert but this undefine solution works, so please check my pull request in your own Qt projects.