### PR TITLE
fix: resolve #254: avoid double close calls while closing sockets

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -387,15 +387,16 @@ namespace sio
 
     void client_impl::on_fail(connection_hdl)
     {
-        if (m_con_state == con_closing) {
-            LOG("Connection failed while closing." << endl);
-            this->close();
-            return;
-        }
-
+        con_state m_con_state_was = m_con_state;
         m_con.reset();
         m_con_state = con_closed;
         this->sockets_invoke_void(&sio::socket::on_disconnect);
+
+        if (m_con_state_was == con_closing) {
+            LOG("Connection failed while closing." << endl);
+            return;
+        }
+
         LOG("Connection failed." << endl);
         if(m_reconn_made<m_reconn_attempts)
         {
@@ -415,16 +416,18 @@ namespace sio
     
     void client_impl::on_open(connection_hdl con)
     {
-        if (m_con_state == con_closing) {
+        con_state m_con_state_was = m_con_state;
+        LOG("Connected." << endl);
+        m_con_state = con_opened;
+        m_con = con;
+        m_reconn_made = 0;
+
+        if (m_con_state_was == con_closing) {
             LOG("Connection opened while closing." << endl);
             this->close();
             return;
         }
 
-        LOG("Connected." << endl);
-        m_con_state = con_opened;
-        m_con = con;
-        m_reconn_made = 0;
         this->sockets_invoke_void(&sio::socket::on_open);
         this->socket("");
         if(m_open_listener)m_open_listener();


### PR DESCRIPTION
Upon long-term usage, I sometimes triggered segmentation faults due to an already freed / closed socket.

The `on_fail` and `on_open` functions need to handle the socket properly.

Test: I will use my patched version for a few days and confirm within next week.

C++ client : [test.cpp](https://github.com/socketio/socket.io-client-cpp/files/6067846/test.cpp.txt)
NodeJS server : [test.js](https://github.com/socketio/socket.io-client-cpp/files/6067847/test.js.txt)

```
docker run --rm -i -v "${PWD}:${PWD}" -w "${PWD}" centos:7.6.1810 <<EOF
# Dependencies
yum install -y cmake gcc gcc-c++ make openssl-devel psmisc
curl -sL https://rpm.nodesource.com/setup_12.x | bash -
yum install -y nodejs
npm install socket.io

# Library
rm -rf ./build
mkdir -p ./build/
cd ./build/
cmake  ../
make install
cd ../

# Build
g++ -std=c++11 -Wall -lpthread -o test254 test.cpp /usr/local/lib*/libsioclient.a

# Test
{
  set +m;
  node ./test.js &
  time timeout -s9 10 ./test254
  killall node
}
EOF
```
