### PR TITLE
Abort retrying when closing down.

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -110,6 +110,7 @@ namespace sio
         m_http_headers = headers;
 
         this->reset_states();
+        m_abort_retries = false;
         m_client.get_io_service().dispatch(std::bind(&client_impl::connect_impl,this,uri,m_query_string));
         m_network_thread.reset(new thread(std::bind(&client_impl::run_loop,this)));//uri lifecycle?
 
@@ -148,6 +149,7 @@ namespace sio
     void client_impl::close()
     {
         m_con_state = con_closing;
+        m_abort_retries = true;
         this->sockets_invoke_void(&sio::socket::close);
         m_client.get_io_service().dispatch(std::bind(&client_impl::close_impl, this,close::status::normal,"End by user"));
     }
@@ -155,6 +157,7 @@ namespace sio
     void client_impl::sync_close()
     {
         m_con_state = con_closing;
+        m_abort_retries = true;
         this->sockets_invoke_void(&sio::socket::close);
         m_client.get_io_service().dispatch(std::bind(&client_impl::close_impl, this,close::status::normal,"End by user"));
         if(m_network_thread)
@@ -397,7 +400,7 @@ namespace sio
         m_con_state = con_closed;
         this->sockets_invoke_void(&sio::socket::on_disconnect);
         LOG("Connection failed." << endl);
-        if(m_reconn_made<m_reconn_attempts)
+        if(m_reconn_made<m_reconn_attempts && !m_abort_retries)
         {
             LOG("Reconnect for attempt:"<<m_reconn_made<<endl);
             unsigned delay = this->next_delay();
@@ -461,7 +464,7 @@ namespace sio
         else
         {
             this->sockets_invoke_void(&sio::socket::on_disconnect);
-            if(m_reconn_made<m_reconn_attempts)
+            if(m_reconn_made<m_reconn_attempts && !m_abort_retries)
             {
                 LOG("Reconnect for attempt:"<<m_reconn_made<<endl);
                 unsigned delay = this->next_delay();

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -38,6 +38,7 @@ typedef websocketpp::config::asio_client client_config;
 #include <asio/error_code.hpp>
 #include <asio/io_service.hpp>
 
+#include <atomic>
 #include <memory>
 #include <map>
 #include <thread>
@@ -233,7 +234,9 @@ namespace sio
         unsigned m_reconn_attempts;
 
         unsigned m_reconn_made;
-        
+
+        std::atomic<bool> m_abort_retries { false };
+
         friend class sio::client;
         friend class sio::socket;
     };


### PR DESCRIPTION
I've ended up in a deadlock when calling `sync_close` while the network thread is caught in a loop of retrying and failing to connect. This prevents that.