### PR TITLE
Make non-cmake installation instructions mimic cmake

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,4 +10,5 @@
 1. Use `git clone --recurse-submodules https://github.com/socketio/socket.io-client-cpp.git` to clone your local repo.
 2. Add `./lib/asio/asio/include`, `./lib/websocketpp` and `./lib/rapidjson/include` to headers search path.
 3. Include all files under `./src` in your project, add `sio_client.cpp`,`sio_socket.cpp`,`internal/sio_client_impl.cpp`, `internal/sio_packet.cpp` to source list.
-4. Include `sio_client.h` in your client code where you want to use it.
+4. Add `BOOST_DATE_TIME_NO_LIB`, `BOOST_REGEX_NO_LIB`, `ASIO_STANDALONE`, `_WEBSOCKETPP_CPP11_STL_` and `_WEBSOCKETPP_CPP11_FUNCTIONAL_` to the preprocessor definitions
+5. Include `sio_client.h` in your client code where you want to use it.


### PR DESCRIPTION
The installation instructions don't make it clear that certain preprocessor definitions have to be added in order to build  successfully(https://github.com/socketio/socket.io-client-cpp/issues/313) and that boost is not needed and its inclusion will still cause errors(https://github.com/socketio/socket.io-client-cpp/issues/318, https://github.com/socketio/socket.io-client-cpp/issues/300).
This change just copies the preprocessor definitions from the CMakeLists file to the installation instructions