### PR TITLE
bugfix: has two connect on connection callback

### DIFF
--- a/src/sio_socket.cpp
+++ b/src/sio_socket.cpp
@@ -269,6 +269,7 @@ namespace sio
     void socket::impl::send_connect()
     {
         NULL_GUARD(m_client);
+        if (m_nsp == "/") return;
         packet p(packet::type_connect,m_nsp);
         m_client->send(p);
         m_connection_timer.reset(new asio::steady_timer(m_client->get_io_service()));


### PR DESCRIPTION
i have woked SioChatDemo with  [socket.io chatroom example](https://github.com/Automattic/socket.io/tree/master/examples/chat) 
and found if i connect with default namespace just for one client, node server will got two connection callback.
it sounds like default namespace don't need to call send connection packet, server will handle it.
and then i make a fixed.

io.on('connection', (socket) => {
  let addedUser = false;
  **console.log("new connection");**
  // when the client emits 'new message', this listens and executes
  socket.on('new message', (data) => {
    // we tell the client to execute 'new message'
    socket.broadcast.emit('new message', {
      username: socket.username,
      message: data
    });
  });
  ...