### PR TITLE
Support TLSv1.2 and newer

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -599,10 +599,12 @@ failed:
 #if SIO_TLS
     client_impl::context_ptr client_impl::on_tls_init(connection_hdl conn)
     {
-        context_ptr ctx = context_ptr(new  asio::ssl::context(asio::ssl::context::tlsv12));
+        context_ptr ctx = context_ptr(new  asio::ssl::context(asio::ssl::context::tls));
         asio::error_code ec;
         ctx->set_options(asio::ssl::context::default_workarounds |
-                             asio::ssl::context::single_dh_use,ec);
+                         asio::ssl::context::no_tlsv1 |
+                         asio::ssl::context::no_tlsv1_1 |
+                         asio::ssl::context::single_dh_use,ec);
         if(ec)
         {
             cerr<<"Init tls failed,reason:"<< ec.message()<<endl;


### PR DESCRIPTION
socket.io-client-cpp is currently hard-coded to use only TLSv1.2. This
commit updates socket.io-client-cpp to use TLSv1.2 or newer.