### PR TITLE
Fix #311, removed unnecessary check for CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,101 +1,101 @@
 cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
-PROJECT(sioclient)
+PROJECT(sioclient
+        VERSION 3.1.0
+        )
 
 option(BUILD_SHARED_LIBS "Build the shared library" OFF)
-option(BUILD_UNIT_TESTS  "Builds unit tests target" OFF)
+option(BUILD_UNIT_TESTS "Builds unit tests target" OFF)
 
-set(MAJOR 1)
-set(MINOR 6)
-set(PATCH 0)
-
-if(NOT CMAKE_BUILD_TYPE )
-MESSAGE(STATUS "not define build type, set to release" )
-set(CMAKE_BUILD_TYPE Release )
-elseif(NOT (${CMAKE_BUILD_TYPE} STREQUAL "Release" OR ${CMAKE_BUILD_TYPE} STREQUAL "Debug" ))
-MESSAGE(SEND_ERROR "CMAKE_BUILD_TYPE must be either Release or Debug")
-return()
-endif()
+if (NOT EXISTS ${CMAKE_SOURCE_DIR}/lib/asio/asio/README)
+    message("Updating submodules")
+    execute_process(
+            COMMAND git submodule update --init
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif ()
 
 aux_source_directory(${CMAKE_CURRENT_LIST_DIR}/src ALL_SRC)
 aux_source_directory(${CMAKE_CURRENT_LIST_DIR}/src/internal ALL_SRC)
-file(GLOB ALL_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/*.h )
-set(SIO_INCLUDEDIR ${CMAKE_CURRENT_LIST_DIR})
+
+file(GLOB ALL_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
 
 add_definitions(
-    # These will force ASIO to compile without Boost
-    -DBOOST_DATE_TIME_NO_LIB
-    -DBOOST_REGEX_NO_LIB
-    -DASIO_STANDALONE
-    # These will force WebsocketPP to compile with C++11
-    -D_WEBSOCKETPP_CPP11_STL_
-    -D_WEBSOCKETPP_CPP11_FUNCTIONAL_
+        # These will force ASIO to compile without Boost
+        -DBOOST_DATE_TIME_NO_LIB
+        -DBOOST_REGEX_NO_LIB
+        -DASIO_STANDALONE
+        # These will force WebsocketPP to compile with C++11
+        -D_WEBSOCKETPP_CPP11_STL_
+        -D_WEBSOCKETPP_CPP11_FUNCTIONAL_
 )
 
 add_library(sioclient ${ALL_SRC})
-target_include_directories(sioclient PRIVATE 
-    ${CMAKE_CURRENT_LIST_DIR}/src 
-    ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp 
-    ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
-    ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
-)
+
+target_include_directories(sioclient PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/src
+        ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp
+        ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
+        ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
+        )
 
 if (CMAKE_VERSION VERSION_GREATER "3.1")
-set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
-set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
-else()
-set_property(TARGET sioclient APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
-endif()
-if(BUILD_SHARED_LIBS)
-set_target_properties(sioclient
-	PROPERTIES
-		SOVERSION ${MAJOR}
-		VERSION ${MAJOR}.${MINOR}.${PATCH}
-	)
-endif()
+    set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
+    set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
+else ()
+    set_property(TARGET sioclient APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
+endif ()
+
+if (BUILD_SHARED_LIBS)
+    set_target_properties(sioclient
+            PROPERTIES
+            SOVERSION ${MAJOR}
+            VERSION ${MAJOR}.${MINOR}.${PATCH}
+            )
+endif ()
+
 list(APPEND TARGET_LIBRARIES sioclient)
 
 find_package(OpenSSL)
-if(OPENSSL_FOUND)
-add_library(sioclient_tls ${ALL_SRC})
-target_include_directories(sioclient_tls PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/src 
-    ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp 
-    ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
-    ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
-    ${OPENSSL_INCLUDE_DIR}
-)
+if (OPENSSL_FOUND)
+    add_library(sioclient_tls ${ALL_SRC})
+    target_include_directories(sioclient_tls PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/src
+            ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp
+            ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
+            ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
+            ${OPENSSL_INCLUDE_DIR}
+            )
 
-if (CMAKE_VERSION VERSION_GREATER "3.1")
-set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
-set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
-target_link_libraries(sioclient_tls PRIVATE ${OPENSSL_LIBRARIES} )
-else()
-set_property(TARGET sioclient_tls APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
-endif()
-target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)
-if(BUILD_SHARED_LIBS)
-set_target_properties(sioclient_tls
-	PROPERTIES
-		SOVERSION ${MAJOR}
-		VERSION ${MAJOR}.${MINOR}.${PATCH}
-	)
-endif()
-list(APPEND TARGET_LIBRARIES sioclient_tls)
+    if (CMAKE_VERSION VERSION_GREATER "3.1")
+        set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
+        set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
+        target_link_libraries(sioclient_tls PRIVATE ${OPENSSL_LIBRARIES})
+    else ()
+        set_property(TARGET sioclient_tls APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
+    endif ()
+    target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)
+    if (BUILD_SHARED_LIBS)
+        set_target_properties(sioclient_tls
+                PROPERTIES
+                SOVERSION ${MAJOR}
+                VERSION ${MAJOR}.${MINOR}.${PATCH}
+                )
+    endif ()
+    list(APPEND TARGET_LIBRARIES sioclient_tls)
 
-endif()
+endif ()
 
 include(GNUInstallDirs)
 
-install(FILES ${ALL_HEADERS} 
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+install(FILES ${ALL_HEADERS}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
 
 install(TARGETS ${TARGET_LIBRARIES}
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
 
-if(BUILD_UNIT_TESTS)
-message(STATUS "Building with unit test support.")
-enable_testing()
-add_subdirectory(test)
-endif()
+if (BUILD_UNIT_TESTS)
+    message(STATUS "Building with unit test support.")
+    enable_testing()
+    add_subdirectory(test)
+endif ()


### PR DESCRIPTION
The check for Release or Debug in CMAKE_BUILD_TYPE breaks some assumption in Debian packaging.
Since the check is useless, it has been removed.