### PR TITLE
[CMake] Make socket.io headers public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,10 @@ add_definitions(
 )
 
 add_library(sioclient ${ALL_SRC})
-target_include_directories(sioclient PRIVATE 
+target_include_directories(sioclient 
+    PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/src 
+    PRIVATE 
     ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp 
     ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
     ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
@@ -57,8 +59,10 @@ list(APPEND TARGET_LIBRARIES sioclient)
 find_package(OpenSSL)
 if(OPENSSL_FOUND)
 add_library(sioclient_tls ${ALL_SRC})
-target_include_directories(sioclient_tls PRIVATE
+target_include_directories(sioclient_tls
+    PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/src 
+    PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp 
     ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
     ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include


### PR DESCRIPTION
You can use the socket.io c++ library as CMake subdirectory by adding `add_subdirectory(socket.io-client-cpp)` to your personal project. However, when doing this the headers cannot be found as they are made private by default.

This PR solves the issue and now the socket.io header library can be properly used as a subdirectory with CMake.