### PR TITLE
Re-enable ping timeout behaviour for 3x branch

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -310,7 +310,7 @@ namespace sio
             return;
         }
         LOG("Ping timeout"<<endl);
-        m_client.get_io_service().dispatch(std::bind(&client_impl::close_impl, this,close::status::policy_violation,"Pong timeout"));
+        m_client.get_io_service().dispatch(std::bind(&client_impl::close_impl, this,close::status::policy_violation,"Ping timeout"));
     }
 
     void client_impl::timeout_reconnect(asio::error_code const& ec)

--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -309,7 +309,6 @@ namespace sio
         {
             return;
         }
-        std::cout << "Ping timed out" << std::endl;
         LOG("Ping timeout"<<endl);
         m_client.get_io_service().dispatch(std::bind(&client_impl::close_impl, this,close::status::policy_violation,"Pong timeout"));
     }
@@ -510,7 +509,6 @@ failed:
 
     void client_impl::on_ping()
     {
-        std::cout << "Got ping " << std::endl;
         // Reply with pong packet.
         packet p(packet::frame_pong);
         m_packet_mgr.encode(p, [&](bool /*isBin*/,shared_ptr<const string> payload)

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -151,7 +151,7 @@ namespace sio
         
         void ping(const asio::error_code& ec);
         
-        void timeout_pong(const asio::error_code& ec);
+        void timeout_ping(const asio::error_code& ec);
 
         void timeout_reconnect(asio::error_code const& ec);
 
@@ -181,6 +181,8 @@ namespace sio
         void reset_states();
 
         void clear_timers();
+
+        void update_ping_timeout_timer();
         
         #if SIO_TLS
         typedef websocketpp::lib::shared_ptr<asio::ssl::context> context_ptr;


### PR DESCRIPTION
After this commit https://github.com/socketio/socket.io-client-cpp/commit/ec4d540ad54593604ac2091e67ffc2a6d9a00db6 the ping timeout behavior was broken.

Fixes:
* Re-enable ping timeout handling.
* Remove ping function that was unused.