### PR TITLE
Update cmake for system install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         submodule_update: ON
         run_tests: ON
         unit_test_build: -DBUILD_UNIT_TESTS=ON
-        cmake_args: -DCMAKE_CXX_FLAGS=-std=c++11
+        cmake_args: -DCMAKE_CXX_FLAGS=-std=c++11 -DUSE_SUBMODULES=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         submodule_update: ON
         run_tests: ON
         unit_test_build: -DBUILD_UNIT_TESTS=ON
-        cmake_args: -DCMAKE_CXX_FLAGS=-std=c++11 -DUSE_SUBMODULES=ON
+        cmake_args: -DCMAKE_CXX_FLAGS=-std=c++11;-DUSE_SUBMODULES=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
 cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    CACHE STRING "Autodetect vcpkg toolchain")
+
 PROJECT(sioclient
-        VERSION 3.1.0
-        )
+    VERSION 3.1.0
+)
 
 option(BUILD_SHARED_LIBS "Build the shared library" OFF)
 option(BUILD_UNIT_TESTS "Builds unit tests target" OFF)
+option(USE_SUBMODULES "Use source in local submodules instead of system libraries" OFF)
 
 set(MAJOR 1)
 set(MINOR 6)
@@ -14,6 +19,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(DEFAULT_BUILD_TYPE "Release")
     message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
     set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
+
     # Set the possible values of build type for cmake-gui
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
@@ -24,82 +30,149 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR}/src/internal ALL_SRC)
 file(GLOB ALL_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
 
 add_definitions(
+
     # These will force ASIO to compile without Boost
     -DBOOST_DATE_TIME_NO_LIB
     -DBOOST_REGEX_NO_LIB
     -DASIO_STANDALONE
-    # These will force WebsocketPP to compile with C++11
+
+    # These will force sioclient to compile with C++11
     -D_WEBSOCKETPP_CPP11_STL_
     -D_WEBSOCKETPP_CPP11_FUNCTIONAL_
+    -D_WEBSOCKETPP_CPP11_TYPE_TRAITS_
+    -D_WEBSOCKETPP_CPP11_CHRONO_
 )
 
 add_library(sioclient ${ALL_SRC})
+
+if(USE_SUBMODULES)
+    set(MODULE_INCLUDE_DIRS
+        ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp
+        ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
+        ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
+    )
+else()
+    find_package(websocketpp CONFIG REQUIRED)
+    find_package(asio CONFIG REQUIRED)
+    find_package(RapidJSON CONFIG REQUIRED)
+    target_link_libraries(sioclient PRIVATE websocketpp::websocketpp asio asio::asio rapidjson)
+endif()
+
 target_include_directories(sioclient PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/src 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp
-    ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
-    ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
+    ${MODULE_INCLUDE_DIRS}
 )
 
-if (CMAKE_VERSION VERSION_GREATER "3.1")
-set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
-set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
+if(CMAKE_VERSION VERSION_GREATER "3.1")
+    set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
+    set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
 else()
-set_property(TARGET sioclient APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
+    set_property(TARGET sioclient APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
 endif()
+
 if(BUILD_SHARED_LIBS)
-set_target_properties(sioclient
-	PROPERTIES
-		SOVERSION ${MAJOR}
-		VERSION ${MAJOR}.${MINOR}.${PATCH}
-	)
+    set_target_properties(sioclient
+        PROPERTIES
+        SOVERSION ${MAJOR}
+        VERSION ${MAJOR}.${MINOR}.${PATCH}
+    )
 endif()
+
 list(APPEND TARGET_LIBRARIES sioclient)
 
 find_package(OpenSSL)
+
 if(OPENSSL_FOUND)
-add_library(sioclient_tls ${ALL_SRC})
-target_include_directories(sioclient_tls PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/src 
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/lib/websocketpp
-    ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson/include
-    ${CMAKE_CURRENT_LIST_DIR}/lib/asio/asio/include
-    ${OPENSSL_INCLUDE_DIR}
-)
+    add_library(sioclient_tls ${ALL_SRC})
+    target_include_directories(sioclient_tls PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        PRIVATE
+        ${MODULE_INCLUDE_DIRS}
+        ${OPENSSL_INCLUDE_DIR}
+    )
 
-if (CMAKE_VERSION VERSION_GREATER "3.1")
-set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
-set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
-target_link_libraries(sioclient_tls PRIVATE ${OPENSSL_LIBRARIES} )
-else()
-set_property(TARGET sioclient_tls APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
-endif()
-target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)
-if(BUILD_SHARED_LIBS)
-set_target_properties(sioclient_tls
-	PROPERTIES
-		SOVERSION ${MAJOR}
-		VERSION ${MAJOR}.${MINOR}.${PATCH}
-	)
-endif()
-list(APPEND TARGET_LIBRARIES sioclient_tls)
+    if(CMAKE_VERSION VERSION_GREATER "3.1")
+        set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
+        set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
 
+        if(NOT USE_SUBMODULES)
+            target_link_libraries(sioclient_tls PRIVATE OpenSSL::SSL OpenSSL::Crypto websocketpp::websocketpp asio asio::asio rapidjson)
+        else()
+            target_link_libraries(sioclient_tls PRIVATE ${OPENSSL_LIBRARIES})
+        endif()
+    else()
+        set_property(TARGET sioclient_tls APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
+    endif()
+
+    target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)
+
+    if(BUILD_SHARED_LIBS)
+        set_target_properties(sioclient_tls
+            PROPERTIES
+            SOVERSION ${MAJOR}
+            VERSION ${MAJOR}.${MINOR}.${PATCH}
+        )
+    endif()
+
+    list(APPEND TARGET_LIBRARIES sioclient_tls)
 endif()
+
+export(PACKAGE sioclient)
 
 include(GNUInstallDirs)
 
-install(FILES ${ALL_HEADERS} 
+install(FILES ${ALL_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(TARGETS ${TARGET_LIBRARIES}
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+install(TARGETS ${TARGET_LIBRARIES} EXPORT sioclientTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# === generate a CMake Config File ===
+include(CMakePackageConfigHelpers)
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/sioclient)
+string(REGEX REPLACE "([^;]+)" "find_dependency(\\1)" _find_dependency_calls "${_package_dependencies}")
+string(REPLACE ";" "\n" _find_dependency_calls "${_find_dependency_calls}")
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfigVersion.cmake"
+    VERSION ${sioclient_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+export(EXPORT sioclientTargets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientTargets.cmake"
+    NAMESPACE sioclient::
+)
+
+configure_package_config_file(sioclientConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfig.cmake"
+    INSTALL_DESTINATION "${ConfigPackageLocation}"
+)
+
+install(EXPORT sioclientTargets
+    NAMESPACE
+    sioclient::
+    DESTINATION
+    ${ConfigPackageLocation}
+)
+install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfigTargets.cmake"
+    DESTINATION
+    ${ConfigPackageLocation}
 )
 
 if(BUILD_UNIT_TESTS)
-message(STATUS "Building with unit test support.")
-enable_testing()
-add_subdirectory(test)
+    message(STATUS "Building with unit test support.")
+    enable_testing()
+    add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,17 +91,13 @@ if(OPENSSL_FOUND)
         ${OPENSSL_INCLUDE_DIR}
     )
 
-    if(CMAKE_VERSION VERSION_GREATER "3.1")
-        set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
-        set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
+    set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
+    set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
 
-        if(NOT USE_SUBMODULES)
-            target_link_libraries(sioclient_tls PRIVATE OpenSSL::SSL OpenSSL::Crypto websocketpp::websocketpp asio asio::asio rapidjson)
-        else()
-            target_link_libraries(sioclient_tls PRIVATE ${OPENSSL_LIBRARIES})
-        endif()
+    if(NOT USE_SUBMODULES)
+        target_link_libraries(sioclient_tls PRIVATE OpenSSL::SSL OpenSSL::Crypto websocketpp::websocketpp asio asio::asio rapidjson)
     else()
-        set_property(TARGET sioclient_tls APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
+        target_link_libraries(sioclient_tls PRIVATE ${OPENSSL_LIBRARIES})
     endif()
 
     target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,10 +94,9 @@ if(OPENSSL_FOUND)
     set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
     set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
 
-    if(NOT USE_SUBMODULES)
-        target_link_libraries(sioclient_tls PRIVATE OpenSSL::SSL OpenSSL::Crypto websocketpp::websocketpp asio asio::asio rapidjson)
-    else()
-        target_link_libraries(sioclient_tls PRIVATE ${OPENSSL_LIBRARIES})
+    target_link_libraries(sioclient_tls PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    if (NOT USE_SUBMODULES) 
+        target_link_libraries(sioclient_tls PRIVATE websocketpp::websocketpp asio asio::asio rapidjson)
     endif()
 
     target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 
-set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-    CACHE STRING "Autodetect vcpkg toolchain")
-
 PROJECT(sioclient
     VERSION 3.1.0
 )

--- a/sioclientConfig.cmake.in
+++ b/sioclientConfig.cmake.in
@@ -1,0 +1,7 @@
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+@_find_dependency_calls@
+
+include("${CMAKE_CURRENT_LIST_DIR}/sioclientTargets.cmake")


### PR DESCRIPTION
This is a fix for #366 that adds the following features:

1. The cmake configuration files are installed so that `find_package` can resolve them correctly.
2. An option to use system installed libraries instead of the built in modules. 