### PR TITLE
feat: basic auth proxy

### DIFF
--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -129,6 +129,8 @@ namespace sio
         void set_logs_quiet();
 
         void set_logs_verbose();
+		
+        void set_proxy_basic_auth(const std::string& uri, const std::string& username, const std::string& password);
 
     protected:
         void send(packet& p);
@@ -203,6 +205,9 @@ namespace sio
         std::string m_query_string;
         std::map<std::string, std::string> m_http_headers;
         message::ptr m_auth;
+        std::string m_proxy_base_url;
+        std::string m_proxy_basic_username;
+        std::string m_proxy_basic_password;
 
         unsigned int m_ping_interval;
         unsigned int m_ping_timeout;

--- a/src/sio_client.cpp
+++ b/src/sio_client.cpp
@@ -66,6 +66,11 @@ namespace sio
     {
         m_impl->clear_socket_listeners();
     }
+	
+    void client::set_proxy_basic_auth(const std::string& uri, const std::string& username, const std::string& password)
+    {
+        m_impl->set_proxy_basic_auth(uri, username, password);
+    }
 
     void client::connect(const std::string& uri)
     {

--- a/src/sio_client.h
+++ b/src/sio_client.h
@@ -87,6 +87,8 @@ namespace sio
         
         void sync_close();
         
+        void set_proxy_basic_auth(const std::string& uri, const std::string& username, const std::string& password);
+		
         bool opened() const;
         
         std::string const& get_sessionid() const;


### PR DESCRIPTION
With existing websocketpp interface, I implement to support basic auth proxy.

Usage:
```cpp
sio::client h;
std::string proxy = "http://127.0.0.1:3128/";
h.set_proxy_basic_auth(proxy, "user", "password");
h.connect("http://127.0.0.1:3000");
```