### PR TITLE
Fix installation and change build default flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         submodule_update: ON
         run_tests: ON
         unit_test_build: -DBUILD_UNIT_TESTS=ON
-        cmake_args: -DCMAKE_CXX_FLAGS=-std=c++11;-DUSE_SUBMODULES=ON
+        cmake_args: -DCMAKE_CXX_FLAGS=-std=c++11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ PROJECT(sioclient
 
 option(BUILD_SHARED_LIBS "Build the shared library" OFF)
 option(BUILD_UNIT_TESTS "Builds unit tests target" OFF)
-option(USE_SUBMODULES "Use source in local submodules instead of system libraries" OFF)
+option(USE_SUBMODULES "Use source in local submodules instead of system libraries" ON)
 
 set(MAJOR 1)
 set(MINOR 6)
@@ -158,7 +158,7 @@ install(
     FILES
     "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfigVersion.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientConfigTargets.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/sioclient/sioclientTargets.cmake"
     DESTINATION
     ${ConfigPackageLocation}
 )


### PR DESCRIPTION
This PR fixes the following:
- The installation was not working due to installing a file with the wrong name
- The flag `USE_SUBMODULES` was set to `OFF` by default which is a different behaviour from what has been done in the past.