### PR TITLE
core: fix logging macro not used in sio_socket.cpp

### DIFF
--- a/src/sio_socket.cpp
+++ b/src/sio_socket.cpp
@@ -8,7 +8,7 @@
 #include <cstdarg>
 #include <functional>
 
-#if DEBUG || _DEBUG
+#if (DEBUG || _DEBUG) && !defined(SIO_DISABLE_LOGGING)
 #define LOG(x) std::cout << x
 #else
 #define LOG(x)


### PR DESCRIPTION
sio_socket.cpp did not use the `SIO_DISABLE_LOGGING` macro. This PR fixes this.