### PR TITLE
build: Bump CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12...3.27 FATAL_ERROR)
 
 PROJECT(sioclient
     VERSION 3.1.0


### PR DESCRIPTION
Sets minimum CMake version to 3.12 and adds maximum to 3.27