### PR TITLE
GNUInstallDirs should be included before usage of CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ else()
     target_link_libraries(sioclient PRIVATE websocketpp::websocketpp asio asio::asio rapidjson)
 endif()
 
+include(GNUInstallDirs)
+
 target_include_directories(sioclient 
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
@@ -120,8 +122,6 @@ if(OPENSSL_FOUND)
 endif()
 
 export(PACKAGE sioclient)
-
-include(GNUInstallDirs)
 
 file(GLOB ALL_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
 install(FILES ${ALL_HEADERS}


### PR DESCRIPTION
If it's included too late, the interface directory will not be populated.

Currently:

```
$ cmake -B _builds -D CMAKE_INSTALL_PREFIX=${HOME}/opt/sioclient
$ cmake --build _builds --target install

$ grep INTERFACE_INCLUDE_DIRECTORIES ${HOME}/opt/sioclient/lib/cmake/sioclient/sioclientTargets.cmake || echo FAIL
FAIL
```

As a workaround, `CMAKE_INSTALL_INCLUDEDIR` can be added explicitly:

```
$ cmake -B _builds -D CMAKE_INSTALL_PREFIX=${HOME}/opt/sioclient -D CMAKE_INSTALL_INCLUDEDIR=include
$ cmake --build _builds --target install

$ grep INTERFACE_INCLUDE_DIRECTORIES ${HOME}/opt/sioclient/lib/cmake/sioclient/sioclientTargets.cmake || echo FAIL
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
```

With this patch:

```
$ cmake -B _builds -D CMAKE_INSTALL_PREFIX=${HOME}/opt/sioclient
$ cmake --build _builds --target install

$ grep INTERFACE_INCLUDE_DIRECTORIES ${HOME}/opt/sioclient/lib/cmake/sioclient/sioclientTargets.cmake || echo FAIL
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
```
