### PR TITLE
Allow using new C++ standards when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(sioclient
 target_compile_features(sioclient PUBLIC cxx_std_11)
 
 find_package(Threads REQUIRED)
-target_link_libraries(sioclient PRIVATE Threads::Threads)
+target_link_libraries(sioclient PUBLIC Threads::Threads)
 
 if(BUILD_SHARED_LIBS)
     set_target_properties(sioclient
@@ -109,7 +109,7 @@ if(OPENSSL_FOUND)
     endif()
 
     target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)
-    target_link_libraries(sioclient_tls PRIVATE Threads::Threads)
+    target_link_libraries(sioclient_tls PUBLIC Threads::Threads)
 
     if(BUILD_SHARED_LIBS)
         set_target_properties(sioclient_tls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if (DISABLE_LOGGING)
     add_definitions(-DSIO_DISABLE_LOGGING)
 endif()
 
-set(ALL_SRC 
+set(ALL_SRC
     "src/sio_client.cpp"
     "src/sio_socket.cpp"
     "src/internal/sio_client_impl.cpp"
@@ -67,7 +67,7 @@ endif()
 
 include(GNUInstallDirs)
 
-target_include_directories(sioclient 
+target_include_directories(sioclient
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -75,8 +75,7 @@ target_include_directories(sioclient
     ${MODULE_INCLUDE_DIRS}
 )
 
-set_property(TARGET sioclient PROPERTY CXX_STANDARD 11)
-set_property(TARGET sioclient PROPERTY CXX_STANDARD_REQUIRED ON)
+target_compile_features(sioclient PUBLIC cxx_std_11)
 
 if(BUILD_SHARED_LIBS)
     set_target_properties(sioclient
@@ -100,11 +99,9 @@ if(OPENSSL_FOUND)
         ${OPENSSL_INCLUDE_DIR}
     )
 
-    set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD 11)
-    set_property(TARGET sioclient_tls PROPERTY CXX_STANDARD_REQUIRED ON)
-
+    targeet_compile_features(sioclient_tls PUBLIC cxx_std_11)
     target_link_libraries(sioclient_tls PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-    if (NOT USE_SUBMODULES) 
+    if (NOT USE_SUBMODULES)
         target_link_libraries(sioclient_tls PRIVATE websocketpp::websocketpp asio asio::asio rapidjson)
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ target_include_directories(sioclient
 
 target_compile_features(sioclient PUBLIC cxx_std_11)
 
+find_package(Threads REQUIRED)
+target_link_libraries(sioclient PRIVATE Threads::Threads)
+
 if(BUILD_SHARED_LIBS)
     set_target_properties(sioclient
         PROPERTIES
@@ -106,6 +109,7 @@ if(OPENSSL_FOUND)
     endif()
 
     target_compile_definitions(sioclient_tls PRIVATE -DSIO_TLS)
+    target_link_libraries(sioclient_tls PRIVATE Threads::Threads)
 
     if(BUILD_SHARED_LIBS)
         set_target_properties(sioclient_tls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if(OPENSSL_FOUND)
         ${OPENSSL_INCLUDE_DIR}
     )
 
-    targeet_compile_features(sioclient_tls PUBLIC cxx_std_11)
+    target_compile_features(sioclient_tls PUBLIC cxx_std_11)
     target_link_libraries(sioclient_tls PRIVATE OpenSSL::SSL OpenSSL::Crypto)
     if (NOT USE_SUBMODULES)
         target_link_libraries(sioclient_tls PRIVATE websocketpp::websocketpp asio asio::asio rapidjson)

--- a/examples/Console/CMakeLists.txt
+++ b/examples/Console/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+find_package(Threads REQUIRED)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeLists.txt)
 add_executable(sio_console_demo main.cpp)
-set_property(TARGET sio_console_demo PROPERTY CXX_STANDARD 11)
-set_property(TARGET sio_console_demo PROPERTY CXX_STANDARD_REQUIRED ON)
 target_link_libraries(sio_console_demo sioclient)
-target_link_libraries(sio_console_demo pthread )
+target_link_libraries(sio_console_demo Threads::Threads)
+target_compile_features(sio_console_demo PRIVATE cxx_std_11)
 message(STATUS ${Boost_INCLUDE_DIRS} )
 #target_include_directories(sio_console_demo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src" ${Boost_INCLUDE_DIRS} )
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,5 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 
 add_executable(sio_test sio_test.cpp)
-set_property(TARGET sio_test PROPERTY CXX_STANDARD 11)
-set_property(TARGET sio_test PROPERTY CXX_STANDARD_REQUIRED ON)
 target_link_libraries(sio_test PRIVATE Catch2::Catch2WithMain sioclient)
 add_test(sioclient_test sio_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,8 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
+find_package(Threads REQUIRED)
+
 add_executable(sio_test sio_test.cpp)
-target_link_libraries(sio_test PRIVATE Catch2::Catch2WithMain sioclient)
+target_link_libraries(sio_test PRIVATE Catch2::Catch2WithMain sioclient Threads::Threads)
 add_test(sioclient_test sio_test)


### PR DESCRIPTION
Hello!

We are packaging Socket IO Client in Conan (PR https://github.com/conan-io/conan-center-index/pull/24112/) and we use multiple C++ standards in our CI, including C++11 and newer versions.

We found that Socket IO is using C++11 only, via set_property() in CMakeLists.txt. So, this PR replaces that function by [target_compile_features](https://cmake.org/cmake/help/latest/command/target_compile_features.html), so we can pass `CMAKE_CXX_STANDARD` and override C++11 to something newer like C++14/17/20/23 (set_property() does not allow override).

Plus, I updated [threads](https://cmake.org/cmake/help/latest/module/FindThreads.html) requirement in the project:
- sio_test.cpp uses thread
- sio_client_impl.h uses thread. It should be public because is listed in the header.
- examples/Console/main.cpp uses thread