### PR TITLE
Flexibilize CMake version and add Conan steps in docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.27 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12...3.27)
 
 PROJECT(sioclient
     VERSION 3.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ else()
     find_package(websocketpp CONFIG REQUIRED)
     find_package(asio CONFIG REQUIRED)
     find_package(RapidJSON CONFIG REQUIRED)
-    target_link_libraries(sioclient PRIVATE websocketpp::websocketpp asio asio::asio rapidjson)
+    target_link_libraries(sioclient PRIVATE websocketpp::websocketpp asio::asio rapidjson)
 endif()
 
 include(GNUInstallDirs)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,3 +26,14 @@ vcpkg install socket-io-client
 ```
 
 The Socket.IO client port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+### With Conan
+
+You can install pre-built binaries for Socket.IO C++ client or build it from source using [Conan](https://conan.io/). Use the following command:
+
+```
+conan install --requires="sioclient/[*]" --build=missing
+```
+
+The Socket.IO client Conan recipe is kept up to date by Conan maintainers and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/conan-io/conan-center-index) on the ConanCenterIndex repository.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Note: Only the WebSocket transport is currently implemented (no fallback to HTTP
 * [With CMAKE](./INSTALL.md#with-cmake)
 * [Without CMAKE](./INSTALL.md#without-cmake)
 * [With VCPKG](./INSTALL.md#with-vcpkg)
+* [With Conan](./INSTALL.md#with-conan)
 * [iOS and OS X](./INSTALL_IOS.md)
  * Option 1: Cocoapods
  * Option 2: Create a static library


### PR DESCRIPTION
Hello!

In this PR I tried new changes that I hope be useful for users, including:

- Before the PR #406, the FATAL_ERROR in CMakeLists.txt version was related to avoid running older versions. Later, was added a maximum CMake version, but the CMake is very compatible between a version and other, so I removed the FATAL_ERROR to allow running the latest CMake version available (3.29.x)

- When consuming Asio, both CMake target (asio::asio) and the library asio are consumed, causing double inclusion. I removed the library to keep CMake target are preference.

- After merging the PR https://github.com/conan-io/conan-center-index/pull/24176 in ConanCenterIndex, the socket-io client cpp is now available in Conan Center (https://conan.io/center/recipes/sioclient?version=cci.20240405) and can be installed via Conan commands. I added an entry in the documentation to explain how to install sioclient via Conan. 

Regards! 