### PR TITLE
feat: Enable binary packets, while handling partial packets

### DIFF
--- a/src/internal/sio_packet.cpp
+++ b/src/internal/sio_packet.cpp
@@ -246,7 +246,6 @@ namespace sio
     bool packet::parse_buffer(const string &buf_payload)
     {
         if (_pending_buffers > 0) {
-            assert(is_binary_message(buf_payload));//this is ensured by outside.
             _buffers.push_back(std::make_shared<string>(buf_payload.data(),buf_payload.size()));
             _pending_buffers--;
             if (_pending_buffers == 0) {
@@ -470,7 +469,7 @@ namespace sio
         unique_ptr<packet> p;
         do
         {
-            if(packet::is_text_message(payload))
+            if(packet::is_text_message(payload) && !(m_partial_packet))
             {
                 p.reset(new packet());
                 if(p->parse(payload))
@@ -482,7 +481,7 @@ namespace sio
                     break;
                 }
             }
-            else if(packet::is_binary_message(payload))
+            else if(packet::is_binary_message(payload) || (m_partial_packet) )
             {
                 if(m_partial_packet)
                 {


### PR DESCRIPTION
This enables binary packets, similarly to https://github.com/socketio/socket.io-client-cpp/issues/299 but it also handles cases where packets might be misinterpreted if they happen to start with a digit.