### PR TITLE
Added connection listener to check when the server is down

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -226,6 +226,11 @@ namespace sio
         if(m_socket_open_listener)m_socket_open_listener(nsp);
     }
 
+    void client_impl::on_client_disconnect(bool const& wasDisconnected)
+    {
+        if(m_connection_listener)m_connection_listener(wasDisconnected);
+    }
+
     /*************************private:*************************/
     void client_impl::run_loop()
     {

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -84,6 +84,8 @@ namespace sio
         SYNTHESIS_SETTER(client::socket_listener,socket_open_listener)
         
         SYNTHESIS_SETTER(client::socket_listener,socket_close_listener)
+
+        SYNTHESIS_SETTER(client::connection_listener,connection_listener)
         
 #undef SYNTHESIS_SETTER
         
@@ -95,6 +97,7 @@ namespace sio
             m_fail_listener = nullptr;
             m_reconnect_listener = nullptr;
             m_reconnecting_listener = nullptr;
+            m_connection_listener = nullptr;
         }
         
         void clear_socket_listeners()
@@ -142,6 +145,8 @@ namespace sio
         void on_socket_closed(std::string const& nsp);
         
         void on_socket_opened(std::string const& nsp);
+
+        void on_client_disconnect(bool const& wasDisconnected);
         
     private:
         void run_loop();
@@ -227,6 +232,7 @@ namespace sio
         client::con_listener m_reconnecting_listener;
         client::reconnect_listener m_reconnect_listener;
         client::close_listener m_close_listener;
+        client::connection_listener m_connection_listener;
         
         client::socket_listener m_socket_open_listener;
         client::socket_listener m_socket_close_listener;

--- a/src/sio_client.cpp
+++ b/src/sio_client.cpp
@@ -58,6 +58,11 @@ namespace sio
     {
         m_impl->set_socket_close_listener(l);
     }
+
+    void client::set_connection_listener(connection_listener const& l)
+    {
+        m_impl->set_connection_listener(l);
+    }
     
     void client::clear_con_listeners()
     {

--- a/src/sio_client.h
+++ b/src/sio_client.h
@@ -30,6 +30,8 @@ namespace sio
             close_reason_normal,
             close_reason_drop
         };
+
+        typedef std::function<void(bool)> connection_listener;
         
         typedef std::function<void(void)> con_listener;
         
@@ -57,6 +59,8 @@ namespace sio
         void set_socket_open_listener(socket_listener const& l);
         
         void set_socket_close_listener(socket_listener const& l);
+
+        void set_connection_listener(connection_listener const& l);
         
         void clear_con_listeners();
         

--- a/src/sio_socket.cpp
+++ b/src/sio_socket.cpp
@@ -351,6 +351,7 @@ namespace sio
             m_connection_timer->cancel();
             m_connection_timer.reset();
         }
+
         m_connected = false;
 		{
 			std::lock_guard<std::mutex> guard(m_packet_mutex);
@@ -377,6 +378,7 @@ namespace sio
             while (!m_packet_queue.empty()) {
                 m_packet_queue.pop();
             }
+            m_client->on_client_disconnect(m_connected);
         }
     }
     


### PR DESCRIPTION
This PR offers an alternative solution to Issue #432.

A new listener has been added to verify the client's connection status with the server. This ensures that events are not emitted without an established connection.