### PR TITLE
build: Add missing <algorithm> include

### DIFF
--- a/src/internal/sio_packet.cpp
+++ b/src/internal/sio_packet.cpp
@@ -9,6 +9,7 @@
 #include <rapidjson/encodedstream.h>
 #include <rapidjson/writer.h>
 #include <cassert>
+#include <algorithm>
 
 #define kBIN_PLACE_HOLDER "_placeholder"
 


### PR DESCRIPTION
Didn't compile when I tried to follow cmake instructions. This was with visual studio. Possibly some includes changed in the STL in the latest version