### PR TITLE
Feature : add set_tls_verify_callback method

### DIFF
--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -87,6 +87,7 @@ namespace sio
         
 #undef SYNTHESIS_SETTER
         
+
         
         void clear_con_listeners()
         {
@@ -188,6 +189,14 @@ namespace sio
         void update_ping_timeout_timer();
         
         #if SIO_TLS
+        std::function<bool(bool, websocketpp::lib::asio::ssl::verify_context&)> verify_callback_cb;
+
+        template <typename VerifyCallback>
+        void set_tls_verify_callback(VerifyCallback callback)
+        {
+            verify_callback_cb = callback;
+        }
+
         typedef websocketpp::lib::shared_ptr<asio::ssl::context> context_ptr;
         
         context_ptr on_tls_init(connection_hdl con);

--- a/src/sio_client.cpp
+++ b/src/sio_client.cpp
@@ -74,6 +74,15 @@ namespace sio
         m_impl->set_proxy_basic_auth(uri, username, password);
     }
 
+    #if SIO_TLS
+    void client::set_tls_verify_callback(std::function<bool(bool, websocketpp::lib::asio::ssl::verify_context&)> callback)
+    {
+        if (m_impl) {
+            m_impl->set_tls_verify_callback(callback);
+        }
+    }
+    #endif
+
     void client::connect(const std::string& uri)
     {
         m_impl->connect(uri, {}, {}, {});

--- a/src/sio_client.h
+++ b/src/sio_client.h
@@ -11,6 +11,10 @@
 #include "sio_message.h"
 #include "sio_socket.h"
 
+#if SIO_TLS
+#include "websocketpp/config/asio_client.hpp"
+#endif
+
 namespace asio {
     class io_context;
 }
@@ -61,6 +65,10 @@ namespace sio
         void clear_con_listeners();
         
         void clear_socket_listeners();
+
+        #if SIO_TLS
+        void set_tls_verify_callback(std::function<bool(bool, websocketpp::lib::asio::ssl::verify_context&)> callback);
+        #endif
         
         // Client Functions - such as send, etc.
         void connect(const std::string& uri);


### PR DESCRIPTION
Adding set_tls_verify_callback method so that one can install a callback to ignore self-signed certificate error on connecting.